### PR TITLE
Blockly_renderer

### DIFF
--- a/Blockly_renderer
+++ b/Blockly_renderer
@@ -1,0 +1,4 @@
+Blockly.inject('blocklyDiv', {
+  toolbox: document.getElementById('toolbox'),
+  renderer: 'zelos'
+});


### PR DESCRIPTION
This renders the style,
**MORE** like rendering a script,
# How it works
It works by using the script
``` JS
Blockly.inject('blocklyDiv', {
  toolbox: document.getElementById('toolbox'),
  renderer: 'zelos'
});

